### PR TITLE
Delete key, not set value to nil

### DIFF
--- a/player.go
+++ b/player.go
@@ -182,6 +182,6 @@ func (player *Player) Destroy() error {
 	if err != nil {
 		return err
 	}
-	player.manager.players[player.guildID] = nil
+	delete(player.manager.players, player.guildID)
 	return nil
 }


### PR DESCRIPTION
When I would call player.destory() I would get a invalid memory address because there seems to be a few places that tries to access the value of the player key. The only down side is that this will fire off a few log lines:

```
(gavalink) Couldn't find a player for that guild
(gavalink) Couldn't find a player for that guild
(gavalink) Couldn't find a player for that guild
```

Because onEvent can't find that player because the key doesn't exist anymore. I'm sure this could be changed but this seems to get the job done.