### PR TITLE
Fix parsing error on Lavalink API version check

### DIFF
--- a/node.go
+++ b/node.go
@@ -44,7 +44,7 @@ func (node *Node) open() error {
 	if err != nil {
 		return err
 	}
-	vstr := resp.Header.Get("Lavalink-Major-Version")
+	vstr := resp.Header.Get("Lavalink-Api-Version")
 	v, err := strconv.Atoi(vstr)
 	if err != nil {
 		return err


### PR DESCRIPTION
For some reason, they have changed the header defining the Lavalink API version on node initialization which causes the following error on loading a track:
```
strconv.Atoi: parsing "": invalid syntax
```

I've changed the name of the header so that the version can be fetched properly.